### PR TITLE
Replace $ with jQuery for noConflict mode

### DIFF
--- a/js/percircle.js
+++ b/js/percircle.js
@@ -1,9 +1,9 @@
-$(document).ready(function () {
+jQuery(document).ready(function () {
 	var rotationMultiplier = 3.6;
 	// For each div that its id ends with "circle", do the following.
-	$( "div[id$='circle']" ).each(function() {
+	jQuery( "div[id$='circle']" ).each(function() {
 		// Save all of its classes in an array.
-		var classList = $( this ).attr('class').split(/\s+/);
+		var classList = jQuery( this ).attr('class').split(/\s+/);
 		// Iterate over the array
 		for (var i = 0; i < classList.length; i++) {
 		   /* If there's about a percentage class, take the actual percentage and apply the
@@ -12,7 +12,7 @@ $(document).ready(function () {
 		   if (classList[i].match("^p")) {
 			var rotationPercentage = classList[i].substring(1, classList[i].length);
 			var rotationDegrees = rotationMultiplier*rotationPercentage;
-			$('.c100.p'+rotationPercentage+ ' .bar').css({
+			jQuery('.c100.p'+rotationPercentage+ ' .bar').css({
 			  '-webkit-transform' : 'rotate(' + rotationDegrees + 'deg)',
 			  '-moz-transform'    : 'rotate(' + rotationDegrees + 'deg)',
 			  '-ms-transform'     : 'rotate(' + rotationDegrees + 'deg)',


### PR DESCRIPTION
When jQuery is in noConflict mode, the $ operator can be claimed by other frameworks (ProtoType, MooTools). To avoid JS errors, jQuery plugins should not use $ but jQuery instead.