### PR TITLE
#4 Added options to manipulate border color, text color, and fill color

### DIFF
--- a/css/percircle.css
+++ b/css/percircle.css
@@ -1,117 +1,3 @@
-.percircle.dark {
-  background-color: #777777;
-}
-.percircle.dark .bar,
-.percircle.dark .fill {
-  border-color: #c6ff00;
-}
-.percircle.dark > span {
-  color: #777777;
-}
-.percircle.dark:after {
-  background-color: #555555;
-}
-.percircle.dark:hover > span {
-  color: #c6ff00;
-}
-.percircle.red .bar,
-.percircle.red .fill {
-  border-color: #dd5454;
-}
-.percircle.red:hover > span {
-  color: #dd5454;
-}
-.percircle.red.dark .bar,
-.percircle.red.dark .fill {
-  border-color: #f84a4a;
-}
-.percircle.red.dark:hover > span {
-  color: #f84a4a;
-}
-.percircle.blue .bar,
-.percircle.blue .fill {
-  border-color: #82cefa;
-}
-.percircle.blue:hover > span {
-  color: #82cefa;
-}
-.percircle.blue.dark .bar,
-.percircle.blue.dark .fill {
-  border-color: #20cceb;
-}
-.percircle.blue.dark:hover > span {
-  color: #20cceb;
-}
-.percircle.green .bar,
-.percircle.green .fill {
-  border-color: #8dea7b;
-}
-.percircle.green:hover > span {
-  color: #8dea7b;
-}
-.percircle.green.dark .bar,
-.percircle.green.dark .fill {
-  border-color: #a9ff3a;
-}
-.percircle.green.dark:hover > span {
-  color: #a9ff3a;
-}
-.percircle.orange .bar,
-.percircle.orange .fill {
-  border-color: #e88239;
-}
-.percircle.orange:hover > span {
-  color: #e88239;
-}
-.percircle.orange.dark .bar,
-.percircle.orange.dark .fill {
-  border-color: #dc5b00;
-}
-.percircle.orange.dark:hover > span {
-  color: #dc5b00;
-}
-.percircle.pink .bar,
-.percircle.pink .fill {
-  border-color: #ff8ed0;
-}
-.percircle.pink:hover > span {
-  color: #ff8ed0;
-}
-.percircle.pink.dark .bar,
-.percircle.pink.dark .fill {
-  border-color: #ff58b9;
-}
-.percircle.pink.dark:hover > span {
-  color: #ff58b9;
-}
-.percircle.purple .bar,
-.percircle.purple .fill {
-  border-color: #aa7eff;
-}
-.percircle.purple:hover > span {
-  color: #aa7eff;
-}
-.percircle.purple.dark .bar,
-.percircle.purple.dark .fill {
-  border-color: #7a38f7;
-}
-.percircle.purple.dark:hover > span {
-  color: #7a38f7;
-}
-.percircle.yellow .bar,
-.percircle.yellow .fill {
-  border-color: #dcbd00;
-}
-.percircle.yellow:hover > span {
-  color: #dcbd00;
-}
-.percircle.yellow.dark .bar,
-.percircle.yellow.dark .fill {
-  border-color: #ffdb00;
-}
-.percircle.yellow.dark:hover > span {
-  color: #ffdb00;
-}
 .rect-auto,
 .percircle.gt50 .slice {
   clip: rect(auto, auto, auto, auto);
@@ -171,7 +57,7 @@
   box-sizing: content-box;
 }
 .percircle.animate > span,
-.percircle.animate:after {
+.percircle.animate .after {
   -webkit-transition: -webkit-transform 0.2s ease-in-out;
   -moz-transition: -moz-transform 0.2s ease-in-out;
   -ms-transition: -ms-transform 0.2s ease-in-out;
@@ -208,7 +94,7 @@
   text-align: center;
   white-space: nowrap;
 }
-.percircle:after {
+.percircle .after {
   position: absolute;
   top: 0.08em;
   left: 0.08em;
@@ -240,7 +126,7 @@
   transform: scale(1.3);
   color: #307bbb;
 }
-.percircle:hover:after {
+.percircle:hover .after {
   -webkit-transform: scale(1.1);
   -moz-transform: scale(1.1);
   -ms-transform: scale(1.1);

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
     <script type="text/javascript" src="js/percircle.js"></script>
-    
+
     <!-- styles for this little demo page -->
     <style type="text/css">
         body {
@@ -40,50 +40,50 @@
 <body>
     <div class="page">
         <h1>percircle</h1>
-        
+
         <h2>Color variants</h2>
         <!-- some colors -->
         <div class="clearfix">
             <div id="bluecircle" data-percent="17" class="big">
             </div>
-            <div id="orangecircle" data-percent="37" class="orange">
+            <div id="orangecircle" data-percent="57" data-border-color="#e88239" data-text-color="#e88239">
             </div>
-            <div id="greencircle" data-percent="94" class="small green">
+            <div id="greencircle" data-percent="94" class="small" data-border-color="#8dea7b" data-text-color="#8dea7b">
             </div>
         </div>
         <!-- /some colors -->
-        
-        <h2>Custom text</h2>
-        <!-- custom text -->
-        <div class="clearfix">
-            <div id="pinkcircle" data-text="work" data-percent="65" class="red big"></div>
-            <div id="bluecircle" data-text="rest" data-percent="87" class="purple"></div>
-            <div id="bluecircle" data-text="play" data-percent="30" class="small blue"></div>
-        </div>
-        <!-- /custom text  -->
 
         <h2>Dark theme</h2>
         <!-- .dark-area -->
         <div class="dark-area clearfix">
             <!-- some colors -->
             <div class="clearfix">
-                <div id="lightcircle" data-percent="77" class="dark big"></div>
-                <div id="dgreencircle" data-percent="50" class="dark blue"></div>
-                <div id="sacircle" data-percent="33" class="dark small pink"></div>
+                <div id="lightcircle" data-percent="77" class="big" data-background-color="#555"></div>
+                <div id="orangecircle" data-percent="57" data-border-color="#e88239" data-text-color="#e88239" data-background-color="#555"></div>
+                <div id="sacircle" data-percent="33" class="small" data-background-color="#555" data-border-color="#ff8ed0" data-text-color="#ff8ed0"></div>
             </div>
             <!-- /some colors -->
         </div>
-        
+
+        <h2>Custom text</h2>
+        <!-- custom text -->
+        <div class="clearfix">
+            <div id="pinkcircle" data-text="work" data-percent="65" class="big" data-border-color="#f84a4a" data-text-color="#f84a4a"></div>
+            <div id="bluecircle" data-text="rest" data-percent="87" data-border-color="#aa7eff" data-text-color="#aa7eff"></div>
+            <div id="bluecircle" data-text="play" data-percent="30" class="small" data-border-color="#307bbb" data-text-color="#307bbb"></div>
+        </div>
+        <!-- /custom text  -->
+
         <h2>Animation off</h2>
         <!-- .animation-off -->
         <div class="dark-area clearfix">
             <!-- some colors -->
             <div class="clearfix">
-                <div id="redcircle" data-percent="43" data-animate="false" class="dark red big"></div>
+                <div id="redcircle" data-percent="43" data-animate="false" class="big" data-background-color="#f5f5f5"></div>
             </div>
             <!-- /some colors -->
         </div><!-- /.animation-off -->
-        
+
         <h2>Custom options</h2>
         <div class="clearfix">
             <!-- custom options -->
@@ -92,22 +92,28 @@
             </div>
             <pre>
     $("#custom").perCircle({
-        text:"custom",
-        percent: 27
+        text: "custom",
+        percent: 27,
+        borderColor: '#dcbd00',
+        textColor: '#dcbd00',
+        backgroundColor: '#eef'
     });
             </pre>
             <!-- /custom options -->
         </div>
-        
+
         <small>Thodoris Bais | <a href="http://thodorisbais.blogspot.com.net">Blog</a></small>
     </div>
-    
+
     <script type="text/javascript">
         $(function(){
             $("[id$='circle']").perCircle();
             $("#custom").perCircle({
                 text:"custom",
-                percent: 27
+                percent: 27,
+                borderColor: '#dcbd00',
+                textColor: '#dcbd00',
+                backgroundColor: '#eef'
             });
         });
     </script>

--- a/js/percircle.js
+++ b/js/percircle.js
@@ -19,10 +19,10 @@
             var perCircle = $(this);
             // add percircle class for styling
             if (!perCircle.hasClass('percircle')) perCircle.addClass('percircle');
-						// add divs for structure
+            // add divs for structure
             $('<div class="slice"><div class="bar"></div><div class="fill"></div></div>').appendTo(perCircle);
 
-						// apply options
+            // apply options
             if (typeof(perCircle.attr('data-animate')) !== 'undefined') options.animate = perCircle.attr('data-animate') == 'true';
             if (options.animate) perCircle.addClass('animate');
             var percent = perCircle.attr('data-percent') || options.percent || 0;

--- a/js/percircle.js
+++ b/js/percircle.js
@@ -2,36 +2,66 @@
     $.fn.perCircle = function(options) {
         // default options
         var defaultOptions = {
-            animate: true
+            animate: true,
+            borderColor: '#307bbb',
+            textColor: '#307bbb',
+            backgroundColor: '#fff'
         };
-        
+
         // extend with any provided options
         if (!options) options = {};
-        $.extend(options, defaultOptions);
-        
+        $.extend(defaultOptions, options);
+
         var rotationMultiplier = 3.6;
-        
+
         // for each element matching selector
         return this.each(function(){
             var perCircle = $(this);
             // add percircle class for styling
             if (!perCircle.hasClass('percircle')) perCircle.addClass('percircle');
-            // apply options
+						// add divs for structure
+            $('<div class="slice"><div class="bar"></div><div class="fill"></div></div>').appendTo(perCircle);
+
+						// apply options
             if (typeof(perCircle.attr('data-animate')) !== 'undefined') options.animate = perCircle.attr('data-animate') == 'true';
             if (options.animate) perCircle.addClass('animate');
             var percent = perCircle.attr('data-percent') || options.percent || 0;
-            if (percent > 50) perCircle.addClass('gt50');
+
+            //Apply border color
+            var borderColor = perCircle.data('border-color') || options.borderColor;
+            if (percent > 50) {
+              perCircle.addClass('gt50');
+              perCircle.css('border-color', borderColor);
+            }
+            perCircle.find('.bar, .fill').css('border-color', borderColor);
+
+            //Add text and apply text color
             var text = perCircle.attr('data-text') || options.text || percent + '%';
             $('<span>'+text+'</span>').appendTo(perCircle);
-            // add divs for structure
-            $('<div class="slice"><div class="bar"></div><div class="fill"></div></div>').appendTo(perCircle);
+            var span = perCircle.find('span');
+            var textColor = perCircle.data('text-color') || options.textColor;
+            perCircle.hover(
+              function(){
+                  span.css('color', textColor);
+              },
+              function(){
+                  span.css('color', '');
+              }
+            );
+
+            //Add child element to apply background color
+            var after = $('<div class="after"></div>');
+            after.appendTo(perCircle);
+            var backgroundColor = perCircle.data('background-color') || options.backgroundColor;
+            after.css('background-color', backgroundColor);
+
             if (percent > 50)
             $('.bar', perCircle).css({
-              '-webkit-transform' : 'rotate(' + 180 + 'deg)',
-              '-moz-transform'    : 'rotate(' + 180 + 'deg)',
-              '-ms-transform'     : 'rotate(' + 180 + 'deg)',
-              '-o-transform'      : 'rotate(' + 180 + 'deg)',
-              'transform'         : 'rotate(' + 180 + 'deg)'
+              '-webkit-transform' : 'rotate(180deg)',
+              '-moz-transform'    : 'rotate(180deg)',
+              '-ms-transform'     : 'rotate(180deg)',
+              '-o-transform'      : 'rotate(180deg)',
+              'transform'         : 'rotate(180deg)'
             });
             var rotationDegrees = rotationMultiplier * percent;
             // set timeout causes the animation to be visible on load


### PR DESCRIPTION
I removed all the cosmetic styles from the CSS and allowed for styles to be declared directly on elements via data-* attributes or programmatically via the options object we pass in. 